### PR TITLE
Added support for tokenizing Chinese

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ conda install --file requirements.txt
 ```
 
 * Download the English model using ```python -m spacy download en```
+
+To tokenize Chinese, [jieba](https://github.com/fxsjy/jieba) must be installed
    
 ## Installation
 Run tests with

--- a/parser.q
+++ b/parser.q
@@ -40,7 +40,9 @@ parser.i.q2spacy:(!). flip(
 parser.i.newParser:{[lang;opts]
   opts:distinct opts,raze parser.i.depOpts colnames:opts;
   disabled:`ner`tagger`parser except opts;
-  model:.p.import[`spacy;`:load][lang;`disable pykw disabled];
+  model: $[lang ~ `zh;
+    .p.import[`spacy.lang.zh][`:Chinese][`disable pykw disabled];
+    .p.import[`spacy;`:load][lang;`disable pykw disabled]];
   if[(`sbd in opts)&`parser in disabled;model[`:add_pipe]model[`:create_pipe;`sbd]];
   tokenAttrs:parser.i.q2spacy key[parser.i.q2spacy]inter opts;
   pyParser:parser.i.parseText[model;tokenAttrs;opts;];


### PR DESCRIPTION
Since there is no model for Chinese, just a tokenizer, there needs to be a separate codepath to handle `zh, as spacy.load only works for proper models.